### PR TITLE
embark build wasn't deploying assets

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -151,7 +151,13 @@ var Embark = {
         });
       },
       function buildPipeline(abi, callback) {
-        var pipeline = new Pipeline({});
+        self.logger.trace("Building Assets");
+        var pipeline = new Pipeline({
+          buildDir: self.config.buildDir,
+          contractsFiles: self.config.contractsFiles,
+          assetFiles: self.config.assetFiles,
+          logger: self.logger
+        });
         pipeline.build(abi);
         callback();
       }


### PR DESCRIPTION
Even if the ```embark --help``` states the **build** command will deploy and build the dapp at _dist/_, that wasn't happening. The **build** command only deployed contracts in the blockchain, but no assets were deployed whatsoever.

This fixes that.